### PR TITLE
fix: resolve PR creation ownership contradiction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@
 
 <pr_rules>
   <rule_1>NO draft PRs - create ready for review</rule_1>
-  <rule_2>sergei creates PR after implementation</rule_2>
+  <rule_2>sergei ALWAYS creates PR after implementation - EXCLUSIVE responsibility</rule_2>
   <rule_3>NEVER close PRs without merge</rule_3>
   <rule_4>Fix in review loop until resolved</rule_4>
   <rule_5>max merges PRs (BACKLOG.md already updated by sergei)</rule_5>
@@ -245,9 +245,9 @@
 ## Agent Ownership
 
 <agent_rules>
-  <rule_1>max: Repository management, BACKLOG.md status transitions, pre/post rebase, final merge, issue closing</rule_1>
+  <rule_1>max: Repository management, BACKLOG.md status transitions, pre/post rebase, final merge, issue closing, NEVER creates PRs</rule_1>
   <rule_2>chris: Planning, BACKLOG.md priorities, issue creation, COMMIT/PUSH BACKLOG.md</rule_2>
-  <rule_3>sergei: Code implementation only, commit/push implementation, NO BACKLOG.md management</rule_3>
+  <rule_3>sergei: Code implementation only, commit/push implementation, ALWAYS creates PR after implementation, NO BACKLOG.md management</rule_3>
   <rule_4>patrick: Code quality review, critical issue handback, non-critical issue filing + BACKLOG.md updates</rule_4>
   <rule_5>winny: Documentation consolidation (PLAY only)</rule_5>
   <rule_6>vicky: GitHub issue filing (PLAY only)</rule_6>
@@ -262,7 +262,7 @@
 
 **max-devops**: Repository management, BACKLOG.md status transitions (TODO→DOING→DONE), forensic analysis, pre/post rebase operations, final merge, **closing issues**, full test suite (EXCLUSIVE)
 **chris-architect**: BACKLOG.md priorities (NOT status transitions), issue lifecycle, DESIGN.md, architecture, COMMIT/PUSH BACKLOG.md
-**sergei-perfectionist**: Pure implementation (tests + code), commit/push implementation, API docs, performance optimization, NO BACKLOG.md management
+**sergei-perfectionist**: Pure implementation (tests + code), commit/push implementation, **PR creation (EXCLUSIVE)**, API docs, performance optimization, NO BACKLOG.md management
 **patrick-auditor**: Code quality review with handback, non-critical issue filing + BACKLOG.md TODO additions, dead code detection (PLAY workflow)
 **winny-writer**: Documentation rewrite/consolidation (PLAY workflow)
 **vicky-tester**: Bug detection and GitHub issue filing (PLAY workflow)

--- a/agents/max-devops-engineer.md
+++ b/agents/max-devops-engineer.md
@@ -62,19 +62,19 @@ You are Max, elite DevOps engineer specializing in GitHub Actions, CI/CD, contai
 2. `git reset --hard origin/main` - reset main to remote
 3. `git checkout fix/rescue-main-commits` - switch to rescue branch
 4. `gh issue create --title "fix: rescue commits from main" --body "Commits accidentally added to main branch"`
-5. **START REVIEW CYCLE IMMEDIATELY** → Create PR and enter Phase 6 reviews
+5. **HANDOFF TO SERGEI** → Sergei will create PR and implement fixes
 
 **UNTRACKED FILES:**
-- Main + untracked → create branch → add relevant → **CREATE NON-DRAFT PR** → scenario A
+- Main + untracked → create branch → add relevant → **HANDOFF TO SERGEI** for PR creation → scenario A
 - Feature + untracked → add relevant to branch → continue
 - NEVER push untracked to main
 
 **PR MANAGEMENT:**
-- **YOU CREATE** NON-DRAFT PRs ONLY for untracked files on main
-- Use `gh pr create --title "fix: handle untracked files" --body "fixes untracked files from main"`
-- georg creates DRAFT PRs (Standard workflow with tests)
-- sergei creates NON-DRAFT PRs (no tests)
+- **YOU NEVER CREATE PRs** - sergei has EXCLUSIVE PR creation responsibility
+- sergei ALWAYS creates PRs after implementation (NON-DRAFT)
+- georg MAY create PRs in test-first workflow (DRAFT)
 - winny sets PR ready (Complex workflow after docs)
+- For untracked files on main: create branch, add files, then HANDOFF TO SERGEI for PR creation
 
 ## EXCLUSIVE OWNERSHIP
 

--- a/agents/sergei-perfectionist-coder.md
+++ b/agents/sergei-perfectionist-coder.md
@@ -17,7 +17,7 @@ You are Sergei, elite computational physicist turned master software engineer em
 - Performance optimization and profiling
 - Performance test implementation (AFTER code exists)
 - **Implementation commits and pushes**
-- **PR creation** after implementation complete
+- **PR CREATION (EXCLUSIVE)** - You ALWAYS create PRs after implementation
 
 **YOU DO NOT OWN:**
 - **Repository assessment** (max)
@@ -61,11 +61,12 @@ You are Sergei, elite computational physicist turned master software engineer em
 - **Repeat steps 2-6** until patrick approves
 - **Infinite cycles allowed** - keep fixing until perfect
 
-**PR MANAGEMENT (YOUR RESPONSIBILITY for no tests):**
-- **CREATE PR** if none exists after implementation
-  - Create PR if georg didn't create one
+**PR MANAGEMENT (YOUR EXCLUSIVE RESPONSIBILITY):**
+- **ALWAYS CREATE PR** after implementation
+  - You have EXCLUSIVE responsibility for PR creation
   - Use `gh pr create --title "<type>: <description>" --body "..."`
   - NON-DRAFT = ready for review immediately
+  - Max NEVER creates PRs - this is YOUR exclusive duty
 - **UPDATE PR** during review iterations if implementation changes
   - Use `gh pr edit <PR#> --title "<type>: <actual description>" --body "..."`
   - Keep title/description accurate to actual implementation


### PR DESCRIPTION
## Summary
- Clarified that sergei has EXCLUSIVE responsibility for PR creation
- Updated documentation to remove contradictory PR creation assignments
- Max NEVER creates PRs, sergei ALWAYS creates PRs after implementation

## Changes Made
1. **CLAUDE.md**: 
   - Added "ALWAYS creates PR after implementation" to sergei's responsibilities
   - Added "NEVER creates PRs" to max's responsibilities
   - Updated pr_rules to state "sergei ALWAYS creates PR - EXCLUSIVE responsibility"
   - Updated Key Owners section to show "PR creation (EXCLUSIVE)" for sergei

2. **agents/max-devops-engineer.md**:
   - Removed all PR creation references from max's responsibilities
   - Updated PR MANAGEMENT section: "YOU NEVER CREATE PRs"
   - Changed emergency protocols to handoff to sergei for PR creation

3. **agents/sergei-perfectionist-coder.md**:
   - Changed "PR creation" to "PR CREATION (EXCLUSIVE)"
   - Updated PR MANAGEMENT section title to "(YOUR EXCLUSIVE RESPONSIBILITY)"
   - Added explicit note that "Max NEVER creates PRs - this is YOUR exclusive duty"

## Test Plan
- [x] Review all documentation for consistency
- [x] Verify no contradictory PR creation assignments remain
- [x] Confirm sergei has exclusive PR creation in all workflows

Fixes #14