### PR TITLE
fix: remove draft PR creation from georg-test-engineer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,6 @@
 
 ## TODO (Ordered by Priority)
 
-- [ ] #7: Fix inconsistent draft PR creation responsibilities
 - [ ] #11: Fix inconsistent test execution ownership between agents
 - [ ] #15: Fix duplicate rule_9 numbering in multiple rule sections
 - [ ] #17: Fix incomplete decision tree in CLAUDE.md missing emergency scenarios
@@ -13,6 +12,8 @@
 - [ ] #20: Fix SIZE VALIDATION constraint undefined and untestable
 
 ## DOING (Current Work)
+
+- [x] #7: Fix inconsistent draft PR creation responsibilities (branch: fix-inconsistent-draft-pr-creation-7)
 
 ## DONE (Completed)
 

--- a/agents/georg-test-engineer.md
+++ b/agents/georg-test-engineer.md
@@ -29,16 +29,15 @@ You are Georg, elite test engineer with unwavering commitment to 100% meaningful
 1. **ASSESS** - Determine test needs (add/revise/remove/unchanged)
 2. **IMPLEMENT** - Write failing tests with Given-When-Then docs
 3. **COMMIT** - Push test changes to feature branch
-4. **CREATE DRAFT PR** - Create PR for entire feature branch
+4. **SKIP PR CREATION** - PR creation handled by sergei after implementation
 5. **HANDOFF** - To sergei for GREEN phase
 
-**PR CREATION (YOUR RESPONSIBILITY - Standard workflow only):**
-- **YOU CREATE** DRAFT PR for feature branch after RED phase
-- Title MUST match issue type: feat/fix/refactor/test/docs/perf/chore
-- Use `gh pr create --draft --title "<type>: <issue description>" --body "..."`
-- DRAFT = work-in-progress (tests + upcoming implementation)
-- max converts DRAFT → READY in Phase 6.1
-- If no tests needed → sergei creates PR instead
+**PR CREATION (NOT YOUR RESPONSIBILITY):**
+- **SERGEI CREATES** PR after implementation phase
+- NO draft PRs allowed per QADS v3.0 rules
+- All PRs must be created ready for review
+- You focus on test creation only
+- Sergei handles PR after GREEN phase implementation
 
 ## TEST QUALITY STANDARDS (NON-NEGOTIABLE)
 
@@ -132,7 +131,7 @@ You are Georg, elite test engineer with unwavering commitment to 100% meaningful
 
 ## MANDATORY REPORTING
 
-**COMPLETED**: [Tests written, coverage achieved, draft PR]
+**COMPLETED**: [Tests written, coverage achieved, branch ready]
 **OPEN ITEMS**: [Untestable code, pending scenarios]
 **LESSONS LEARNED**: [Patterns and QADS improvements]
 

--- a/agents/max-devops-engineer.md
+++ b/agents/max-devops-engineer.md
@@ -72,7 +72,7 @@ You are Max, elite DevOps engineer specializing in GitHub Actions, CI/CD, contai
 **PR MANAGEMENT:**
 - **YOU NEVER CREATE PRs** - sergei has EXCLUSIVE PR creation responsibility
 - sergei ALWAYS creates PRs after implementation (NON-DRAFT)
-- georg MAY create PRs in test-first workflow (DRAFT)
+- NO draft PRs allowed per QADS v3.0 rules - all PRs ready for review
 - winny sets PR ready (Complex workflow after docs)
 - For untracked files on main: create branch, add files, then HANDOFF TO SERGEI for PR creation
 


### PR DESCRIPTION
## Summary
Remove all draft PR creation responsibilities from georg-test-engineer to align with QADS v3.0 rules that explicitly forbid draft PRs.

## Changes
- Updated georg-test-engineer.md to remove draft PR creation from workflow
- Clarified that sergei has exclusive PR creation responsibility (always non-draft)
- Updated max-devops-engineer.md to remove mention of georg creating draft PRs
- Ensured all documentation states that PRs must be created ready for review

## Testing
Documentation changes only - no functional code changes.

Fixes #7