### PR TITLE
fix: correct duplicate rule_9 numbering in CLAUDE.md

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,6 @@
 
 ## TODO (Ordered by Priority)
 
-- [ ] #15: Fix duplicate rule_9 numbering in multiple rule sections
 - [ ] #17: Fix incomplete decision tree in CLAUDE.md missing emergency scenarios
 - [ ] #18: Fix workflow shortcuts not defined or testable in current system
 - [ ] #19: Fix PLAY workflow DONE section clearing creates undefined behavior
@@ -11,6 +10,8 @@
 - [ ] #20: Fix SIZE VALIDATION constraint undefined and untestable
 
 ## DOING (Current Work)
+
+- [x] #15: Fix duplicate rule_9 numbering in multiple rule sections (branch: fix-duplicate-rule9-numbering-15)
 
 ## DONE (Completed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@
   <rule_7>🚨 CRITICAL: sergei MUST NOT start new work when READY PRs exist - fix non-draft PR defects FIRST</rule_7>
   <rule_8>🚨 CRITICAL: max MUST NOT finish workflow until ALL READY PRs merged and CI passes</rule_8>
   <rule_9>🚨 DRAFT PR EXCEPTION: Draft PRs are COMPLETELY IGNORED - treat as if they don't exist</rule_9>
-  <rule_9>Display workflow_rules when triggered by process_rules</rule_9>
+  <rule_10>Display workflow_rules when triggered by process_rules</rule_10>
 </workflow_rules>
 
 ## Batch Mode Operations
@@ -232,7 +232,7 @@
   <rule_7>🚨 max MUST wait for CI checks to pass before merging - NO exceptions</rule_7>
   <rule_8>🚨 sergei FORBIDDEN from starting new TODO items when READY PRs exist</rule_8>
   <rule_9>🚨 DRAFT PR EXCEPTION: Draft PRs are COMPLETELY IGNORED in all blocking rules</rule_9>
-  <rule_9>Display pr_rules when triggered by repository_rules</rule_9>
+  <rule_10>Display pr_rules when triggered by repository_rules</rule_10>
 </pr_rules>
 
 <title_rules>
@@ -255,7 +255,7 @@
   <rule_8>🚨 sergei: BLOCKED from new work when READY PRs exist - fix existing non-draft PRs ONLY</rule_8>
   <rule_9>🚨 max: MUST wait for CI completion before merging - workflow incomplete until merged</rule_9>
   <rule_10>🚨 DRAFT PR EXCEPTION: Draft PRs do NOT block any work or trigger any rules</rule_10>
-  <rule_10>Display agent_rules when triggered by process_rules</rule_10>
+  <rule_11>Display agent_rules when triggered by process_rules</rule_11>
 </agent_rules>
 
 ### Key Owners


### PR DESCRIPTION
## Summary
- Fixed duplicate rule_9 numbering in workflow_rules section (lines 174-175)
- Fixed duplicate rule_9 numbering in pr_rules section (lines 234-235) 
- Fixed duplicate rule_10 numbering in agent_rules section (lines 257-258)
- All rule sections now have proper sequential numbering

## Changes
- workflow_rules: rule_9 → rule_9, rule_10
- pr_rules: rule_9 → rule_9, rule_10
- agent_rules: rule_10 → rule_10, rule_11

## Test plan
- [x] Verified all rule numbers are now sequential
- [x] No content changes, only numbering corrections
- [x] File syntax and structure preserved

fixes #15