### PR TITLE
fix: add missing emergency rescue protocol to main decision tree

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,6 +2,7 @@
 
 ## TODO (Ordered by Priority)
 
+- [ ] #32: Fix duplicate rule numbering in CLAUDE.md sections
 - [ ] #18: Fix workflow shortcuts not defined or testable in current system
 - [ ] #19: Fix PLAY workflow DONE section clearing creates undefined behavior
 - [ ] #8: Fix obsolete emergency rescue protocol references commits on main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,15 @@
 - **Single PR exists** → Continue existing work
 - **No PRs, DOING exists** → Continue implementation
 - **Clean state** → Pick next TODO, create branch
+- **🚨 Local commits on main** → **EMERGENCY RESCUE PROTOCOL**
 - **BACKLOG.md empty** → PLAY workflow
+
+**EMERGENCY RESCUE PROTOCOL (commits on main):**
+1. `git branch fix/rescue-main-commits main` - create rescue branch
+2. `git reset --hard origin/main` - reset main to remote
+3. `git checkout fix/rescue-main-commits` - switch to rescue branch
+4. `gh issue create --title "fix: rescue commits from main" --body "Commits accidentally added to main branch"`
+5. **HANDOFF TO SERGEI** → Sergei will create PR and implement fixes
 
 ## PR Management
 


### PR DESCRIPTION
## Summary
- Add missing 'Local commits on main → EMERGENCY RESCUE PROTOCOL' scenario to main decision tree
- Include complete emergency rescue protocol steps after decision tree  
- Ensures main CLAUDE.md has complete coverage matching max-devops-engineer.md

## Problem Fixed
The main CLAUDE.md decision tree was incomplete compared to max-devops-engineer.md, missing the critical "Local commits on main" emergency scenario. This created:
1. Incomplete guidance in main documentation
2. Risk of repository corruption if users don't know emergency protocols
3. Inconsistency between main docs and agent-specific docs

## Changes Made
1. **Decision Tree Enhancement**: Added `🚨 Local commits on main → EMERGENCY RESCUE PROTOCOL` to main decision tree (line 221)
2. **Protocol Documentation**: Added complete emergency rescue protocol steps (lines 224-229) including:
   - Create rescue branch from main
   - Reset main to remote state
   - Switch to rescue branch  
   - Create GitHub issue
   - Handoff to sergei for PR creation

## Test Plan
- [x] Verify decision tree now includes all scenarios from max-devops-engineer.md
- [x] Confirm emergency protocol steps are complete and actionable
- [x] Validate formatting consistency with existing documentation

fixes #17

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>