### PR TITLE
fix: PLAY workflow DONE section clearing creates undefined behavior

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,12 +2,13 @@
 
 ## TODO (Ordered by Priority)
 
-- [ ] #19: Fix PLAY workflow DONE section clearing creates undefined behavior
 - [ ] #8: Fix obsolete emergency rescue protocol references commits on main
 - [ ] #9: Fix dead code in agent ownership documentation
 - [ ] #20: Fix SIZE VALIDATION constraint undefined and untestable
 
 ## DOING (Current Work)
+
+- [x] #19: Fix PLAY workflow DONE section clearing creates undefined behavior (branch: fix-play-workflow-done-clearing-19)
 
 
 ## DONE (Completed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@
 1. **max**: Pull latest main, git clean -fdx, assess infrastructure
 2. **winny**: Complete documentation rewrite (full codebase)
 3. **Parallel audits**: patrick (dead code), vicky (bugs) - MUST file GitHub issues immediately, NO code changes
-4. **chris**: Clear DONE section completely, update BACKLOG.md with new issues, commit and push
+4. **chris**: Archive DONE section to DONE_ARCHIVE.md, add new defect issues to TODO, commit and push
 **Focus**: Find DEFECTS ONLY - bugs, dead code, obsolete docs (NO features)
 
 ## BACKLOG.md Management
@@ -159,8 +159,8 @@
 **Chris's BACKLOG.md Workflow (Explicit Protocol)**:
 1. **Create/update GitHub issues**: `gh issue create` or `gh issue edit`
 2. **Edit BACKLOG.md**: Add new issues to TODO section, reorder by priority
-3. **PLAY mode only**: Clear DONE section completely before adding new TODO issues
-4. **MANDATORY**: Commit and push immediately: `git add BACKLOG.md && git commit -m "plan: add/update issues in BACKLOG.md" && git push`
+3. **PLAY mode only**: Archive DONE section to DONE_ARCHIVE.md (preserving work history), add new defect TODO issues
+4. **MANDATORY**: Commit and push immediately: `git add BACKLOG.md DONE_ARCHIVE.md && git commit -m "plan: add/update issues in BACKLOG.md" && git push`
 
 <workflow_rules>
   <rule_1>BACKLOG.md: TODO → DOING → DONE tracking</rule_1>
@@ -325,6 +325,33 @@
   <rule_3>User has ULTIMATE AUTHORITY</rule_3>
   <rule_4>Display override_rules when triggered by process_rules</rule_4>
 </override_rules>
+
+## PLAY Workflow DONE Archival
+
+**Archive Process (chris-architect)**:
+1. **Before starting new PLAY cycle**: Check if DONE section contains completed work
+2. **Archive to DONE_ARCHIVE.md**: Append DONE entries with cycle timestamp
+3. **Clear BACKLOG.md DONE**: Remove entries only AFTER successful archival
+4. **Preserve history**: DONE_ARCHIVE.md maintains complete work history across cycles
+5. **Timing**: Archive occurs only when new defect issues are found to add to TODO
+
+**DONE_ARCHIVE.md Format**:
+```markdown
+# Completed Work History
+
+## PLAY Cycle 2024-08-24
+- [x] #15: Fix duplicate rule numbering in CLAUDE.md
+- [x] #11: Update test execution ownership documentation
+
+## PLAY Cycle 2024-08-20  
+- [x] #7: Clarify agent responsibilities in workflow
+```
+
+**Benefits**:
+- Preserves complete work history
+- Enables cycle tracking and metrics
+- Prevents accidental loss of completion records
+- Provides audit trail for all resolved issues
 
 ## PLAY Workflow Constraints
 


### PR DESCRIPTION
## Summary

- Replaces problematic DONE section clearing with archival process
- Preserves complete work history across PLAY cycles  
- Defines precise timing and prevents data loss
- Adds audit trail for all resolved issues

## Changes Made

**PLAY Workflow Protocol Update:**
- Step 4: Archive DONE section to DONE_ARCHIVE.md instead of clearing
- Preserve work history with cycle timestamps
- Clear BACKLOG.md DONE only after successful archival

**Chris BACKLOG.md Workflow Update:**  
- Step 3: Archive DONE section to DONE_ARCHIVE.md in PLAY mode
- Update commit command to include DONE_ARCHIVE.md
- Clarify timing: archive only when new defects found

**New DONE Archival Documentation:**
- Archive process with 5 clear steps
- DONE_ARCHIVE.md format specification
- Benefits and audit trail explanation
- Precise timing definition

## Problems Solved

✅ **Work history preservation** - No more loss of completed work records  
✅ **Clear timing definition** - Archive occurs only when new defects found  
✅ **Audit trail** - Complete history with cycle timestamps  
✅ **Data safety** - Archive before clearing, never lose data  
✅ **Workflow clarity** - Unambiguous steps and responsibilities  

## Test Plan

- [x] Updated PLAY workflow protocol step 4
- [x] Updated Chris BACKLOG.md workflow step 3  
- [x] Added comprehensive DONE archival documentation
- [x] Verified all timing ambiguities resolved
- [x] Ensured work history preservation

Fixes #19

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>